### PR TITLE
make toolbar buttons work from any page

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -97,7 +97,7 @@ tag = "tags"
 
   [[menu.main]]
       name = "Home"
-      url = "#top"
+      url = "/#top"
       weight = 1
 
   [[menu.main]]
@@ -107,26 +107,26 @@ tag = "tags"
 
   [[menu.main]]
       name = "Publications"
-      url = "#publications"
+      url = "/#publications"
       weight = 3
 
     [[menu.main]]
       name = "Projects"
-      url = "#projects"
+      url = "/#projects"
       weight = 4
 
   [[menu.main]]
       name = "Members"
-      url = "#members"
+      url = "/#members"
       weight = 5
 
   [[menu.main]]
       name = "Blog"
-      url = "#posts"
+      url = "/#posts"
       weight = 6
 
 
   [[menu.main]]
       name = "Contact"
-      url = "#contact"
+      url = "/#contact"
       weight = 7


### PR DESCRIPTION
if you are on any page except root, then the current anchors do not work. fixes #45 