### PR TITLE
Some hard-coded values removed to extend the template support to the multilingual functionality offered by hugo

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -67,6 +67,7 @@ tag = "tags"
     subtitle = ""
     str_all = "More Posts"
     str_read_more = "Read more"
+    section_title = "Posts"
 
   # Projects section.
   # Section will only be displayed if there are projects in `content/project/`.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -84,6 +84,12 @@ tag = "tags"
     count = 3
     str_all = "More Vacancies"
 
+  # Team section.
+  [params.team]
+    title = "Team"
+    str_all = "Full team"
+    section_title = "Team" # Can be modified, if for example we list only the main members on the homepage
+
   # Contact section.
   [params.contact]
     enable = true

--- a/layouts/partials/index/members.html
+++ b/layouts/partials/index/members.html
@@ -4,7 +4,7 @@
         <!-- Section heading -->
         <div class="row">
             <div class="col-xs-12 col-md-4 section-heading">
-                <h1 class="section-heading"><a href="{{.Site.BaseURL}}/member/{{if .Site.Params.uglyURLs}}index.html{{end}}"> Team </a></h1>
+                <h1 class="section-heading"><a href="{{.Site.BaseURL}}/member/{{if .Site.Params.uglyURLs}}index.html{{end}}">{{ with .Site.Params.team.title }}{{ . | markdownify }}{{ end }}</a></h1>
             </div>
         </div>
 
@@ -21,7 +21,7 @@
         <div>
             <p class="view-all">
                 <a href="{{ .Site.BaseURL }}/member/{{if .Site.Params.uglyURLs}}index.html{{end}}">
-                    Full team
+                    {{ with .Site.Params.team.str_all }}{{ . | markdownify }}{{ end }}
                     <i class="fa fa-angle-double-right"></i>
                 </a>
             </p>

--- a/layouts/section/member.html
+++ b/layouts/section/member.html
@@ -2,7 +2,7 @@
 {{ partial "navbar.html" . }}
 
 <div class="container">
-    <h1>Team</h1>
+    <h1>{{ with .Site.Params.team.section_title }}{{ . | markdownify }}{{ end }}</h1>
     {{ range (sort .Data.Pages ".Params.sort_position") }}
             {{partial "member_li" .}}
     {{ end }}

--- a/layouts/section/post.html
+++ b/layouts/section/post.html
@@ -4,7 +4,7 @@
 <div class="container">
     <div class="row">
         <div class="col-md-12">
-            <h1>Posts</h1>
+            <h1>{{ with .Site.Params.posts.section_title }}{{ . | markdownify }}{{ end }}</h1>
 
             {{ range .Data.Pages.GroupByDate "2006" }}
             <div class="row" id="pub_list">


### PR DESCRIPTION
These changes were necessary to make the template support the multilingual mode offered by Hugo. I guess other teams could also benefit from these changes. 
It seems that other elements could also be modified, but those proposed here were the ones missing, but necessary for our use case