### PR TITLE
to_be_published parameter 

### DIFF
--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -69,9 +69,10 @@
                     <div class="col-xs-12 col-sm-3 pub-row-heading">Date</div>
                     <div class="col-xs-12 col-sm-9" itemprop="datePublished">
                         {{ if .Params.to_be_published }}
-                            To be published in
+                            To be published in {{ dateFormat "January, 2006" .Params.publication_date }}
+                        {{ else }}
+                            {{ .Date.Format "January, 2006" }}
                         {{ end }}
-                        {{ .Date.Format "January, 2006" }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION

The publication date for publications in the past is determined from the `date` parameter.
The `date` parameter is used to rank when the article appears on the website. If the `date` parameter is set to the future, then the article will be hidden until `date` is older than the current date.

For publications that will appear in the future, the `to_be_published` is set to true, and the `publication_date` parameter is used to display the publication date. 

Both [layouts/publication/single.html](https://github.com/biaslab/hugo-academic-group/blob/master/layouts/publication/single.html#L71-L74) and [layouts/partials/publication_li_detailed.html](https://github.com/biaslab/hugo-academic-group/blob/master/layouts/partials/publication_li_detailed.html#L41-L45) will now display the publication date using the same parameter.

Right now, `date` and `publication_date` both serve the same purpose in the end, so we might want to get rid of `publication_date` in a future version of this repo, and automatically determine whether or not a publication is to be published in the future.