### PR TITLE
fix: add guests into check list for publication authors

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -6,6 +6,17 @@
             <a href="{{ .Permalink }}">{{.Params.name}}</a>
         {{end}}
     {{end}}
+    {{ range where site.RegularPages "Section" "guests" }}
+        {{ if eq $current_author.id .Params.id }}
+            {{if isset .Params "external_link"}}
+            <a  href="{{ .Params.external_link }}">
+                {{ .Params.name }}
+            </a>
+            {{else}}
+                {{ .Params.name }}
+            {{end}}
+        {{end}}
+    {{end}}
     {{ range where site.RegularPages "Section" "alumni" }}
         {{ if eq $current_author.id .Params.id }}
             {{if isset .Params "external_link"}}


### PR DESCRIPTION
We broke publication pages, because we are not checking authorship with respect to guests.  